### PR TITLE
add issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -34,9 +34,8 @@ Add anything that can help better understand what's happening. For example: Scre
 <!--screeshots here-->
 
 ### Logs
-<!--logs here-->
 ```
-Past logs here between the quotes
+Past logs here
 ```
 
 # Additional Details

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,51 @@
+---
+name: Bug
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+---
+
+<!--
+Have you read GDG Algiers' [Code of Conduct?](https://github.com/GDGAlgiers/.github/CODE_OF_CONDUCT.md) By filing an Issue, you are expected to comply with it, including treating everyone with respect.
+--> 
+
+
+# Summary
+A brief description of the issue. 
+
+# Debugging steps
+## How to reproduce? 
+Add steps to reproduce the bug
+1. First step
+2. Second step
+3. ...
+
+## Expected behavior
+What you expect to happen in the correct scenario.
+
+## Current behavior
+Describe what actually happens.
+
+## Demonstration
+Add anything that can help better understand what's happening. For example: Screenshots and error Logs. 
+
+### Screenshots
+<!--screeshots here-->
+
+### Logs
+<!--logs here-->
+```
+Past logs here between the quotes
+```
+
+# Additional Details
+Add any additional information, configuration or data that might be necessary to reproduce the issue.
+
+Examples:
+
+- OS: [e.g. Manjaro Linux]
+- OS Version: [e.g. 18.1.0]
+- Language Version: [e.g. Node 16.16]
+- Package Manager Version: [e.g. npm 16]
+- ...

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: GDG Algiers Community server 
+    url: https://discord.gg/7EvsP7eemQ
+    about: Our discord server 
+  - name: GDG Algiers Website
+    url: https://www.gdgalgiers.com/
+    about: Our website

--- a/.github/ISSUE_TEMPLATE/improvement.md
+++ b/.github/ISSUE_TEMPLATE/improvement.md
@@ -1,0 +1,30 @@
+---
+name: Improvement
+about: Suggest an improvement to an existing functionality
+title: ''
+labels: ''
+assignees: ''
+---
+
+<!--
+Have you read GDG Algiers' [Code of Conduct?](https://github.com/GDGAlgiers/.github/CODE_OF_CONDUCT.md) By filing an Issue, you are expected to comply with it, including treating everyone with respect.
+--> 
+
+# Summary
+A brief description of the improvement. 
+
+# Background
+## Motivation and context
+Explain what make you think this enhancement is needed. Make sure to link any exisiting Issues (or Pull Requests) that are related to this one (Whether they are closed or not).
+
+## Suggested Solution
+Describe clearly the solution you'd like to have, and any other possible alternative. 
+
+## Outcome
+Describe briefly what the end results will be, once this issue is solved. 
+
+# Tests Plan
+Explain the tests that should be added/edited to make sure this improvement works, and doesn't affect other parts of the project. 
+
+# Additional Details
+Add any additional and important details.

--- a/.github/ISSUE_TEMPLATE/improvement.md
+++ b/.github/ISSUE_TEMPLATE/improvement.md
@@ -21,7 +21,7 @@ Explain what make you think this enhancement is needed. Make sure to link any ex
 Describe clearly the solution you'd like to have, and any other possible alternative. 
 
 ## Outcome
-Describe briefly what the end results will be, once this issue is solved. 
+Describe briefly what the end result will be, once this issue is solved. 
 
 # Tests Plan
 Explain the tests that should be added/edited to make sure this improvement works, and doesn't affect other parts of the project. 

--- a/.github/ISSUE_TEMPLATE/new-feature.md
+++ b/.github/ISSUE_TEMPLATE/new-feature.md
@@ -22,11 +22,11 @@ Explain what makes you think this new feature is needed. Make sure to link any e
 Describe in details how you think the feature should be implemented.
 
 ## Outcome 
-Describe briefly what the end results will be, once this issue is solved. 
+Describe briefly what the end result will be, once this issue is solved. 
 
 # Tests
 ## Affected features
-State the different existing features that will be broken/affected by this new feature.
+State the different existing features that will be broken/affected (if any) by this new feature.
 
 ## Tests plan
 Explain the tests that should be added/edited to make sure this feature works correctly, and doesn't affect other parts of the project. 

--- a/.github/ISSUE_TEMPLATE/new-feature.md
+++ b/.github/ISSUE_TEMPLATE/new-feature.md
@@ -1,0 +1,35 @@
+---
+name: New Feature
+about: Suggest a new idea for this project.
+title: ''
+labels: ''
+assignees: ''
+---
+
+<!--
+Have you read GDG Algiers' [Code of Conduct?](https://github.com/GDGAlgiers/.github/CODE_OF_CONDUCT.md) By filing an Issue, you are expected to comply with it, including treating everyone with respect.
+--> 
+
+# Summary
+A brief description of the feature. 
+
+# Background
+
+## Motivation and context
+Explain what makes you think this new feature is needed. Make sure to link any exisiting Issues (or Pull Requests) that are related to this one (Whether they are closed or not).
+
+## Proposed solution
+Describe in details how you think the feature should be implemented.
+
+## Outcome 
+Describe briefly what the end results will be, once this issue is solved. 
+
+# Tests
+## Affected features
+State the different existing features that will be broken/affected by this new feature.
+
+## Tests plan
+Explain the tests that should be added/edited to make sure this feature works correctly, and doesn't affect other parts of the project. 
+
+# Additional Details
+Add any additional and important details.

--- a/.github/ISSUE_TEMPLATE/refactor.md
+++ b/.github/ISSUE_TEMPLATE/refactor.md
@@ -1,0 +1,30 @@
+---
+name: Refactor
+about: Refactor the codebase, or a part of it.
+title: ''
+labels: ''
+assignees: ''
+---
+
+<!--
+Have you read GDG Algiers' [Code of Conduct?](https://github.com/GDGAlgiers/.github/CODE_OF_CONDUCT.md) By filing an Issue, you are expected to comply with it, including treating everyone with respect.
+--> 
+
+
+# Summary
+A brief description of the issue. 
+
+# Background
+
+## What should be refactored?
+State the files/folders that will change due to this refactor.
+
+## Why is this refactor needed?
+Explain why you think this refactor is needed and how it will improve the project.
+
+## How will be the result? 
+Describe the expected structure after the refactor is done.
+
+
+# Additional Details
+Add any additional and important details.

--- a/.github/ISSUE_TEMPLATE/testing.md
+++ b/.github/ISSUE_TEMPLATE/testing.md
@@ -1,0 +1,27 @@
+---
+name: Testing
+about: Add, improve or edit tests in the codebase.
+title: ''
+labels: ''
+assignees: ''
+---
+
+<!--
+Have you read GDG Algiers' [Code of Conduct?](https://github.com/GDGAlgiers/.github/CODE_OF_CONDUCT.md) By filing an Issue, you are expected to comply with it, including treating everyone with respect.
+--> 
+
+
+# Summary
+A brief description of the issue. 
+
+# Background
+
+## Type of Test
+Specify the types of tests that should be added(Integration, unit, ...)
+
+## Expected Behavior
+Describe how the result of executing the tests should be.
+
+# Additional Details
+Add any additional and important details.
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# .github
+# GDG Algiers contributing guidelines

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# GDG Algiers contributing guidelines
+# GDG Algiers Default Community Health Files


### PR DESCRIPTION
# Summary
This PR adds different issue templates. Templates help organizing the issues in categories, and help making sure that all the needed details are provided. (See an [example of issue template chooser](https://github.com/RITlug/teleirc/issues/new/choose)) 

# Description
The following templates are added:
- **New feature:** Suggest a new idea for the project.
- **Improvement:** Suggest an improvement to an existing functionality.
- **Refactor:** Refactor the codebase, or a part of it.
- **Bug Report:** Report a bug in the project.
- **Testing:** Add, improve or edit tests in the codebase.

The `config.yml` file is used to customize the templates chooser. (see: [Configuring the template chooser](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser))

# Further work
Once the custom labels are configured for the organization, we can add labels (metadata) in the templates. This will automatically tag the created issue with the specified labels.